### PR TITLE
Build Node Driver Registrar for Windows nodes

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/windows/servercore:1809 as core
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+LABEL description="CSI Node driver registrar"
+
+COPY ./bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
+COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
+USER ContainerAdministrator
+ENTRYPOINT ["/csi-node-driver-registrar.exe"]

--- a/cmd/csi-node-driver-registrar/util_linux.go
+++ b/cmd/csi-node-driver-registrar/util_linux.go
@@ -1,0 +1,27 @@
+// +build linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func umask(mask int) (int, error) {
+	return unix.Umask(mask), nil
+}

--- a/cmd/csi-node-driver-registrar/util_windows.go
+++ b/cmd/csi-node-driver-registrar/util_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+)
+
+func umask(mask int) (int, error) {
+	return -1, errors.New("umask not supported in Windows")
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR adds support to build the Node Driver Registrar as a Windows binary: `csi-node-driver-registrar.exe`. The goal is to be able to build and publish container images for Windows using the Dockerfile.Windows. Daemonsets for CSI node plugins targeting Windows nodes can specify the Windows container packaging the Node Driver Registrar as a side-car just like in Linux.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The changes and build infra necessary to be able to build the Windows containers packaging `csi-node-driver-registrar.exe` is not yet present.

**Does this PR introduce a user-facing change?**:
```release-note
Support Node Driver Registrar on Windows nodes
```
