### PR TITLE
Update release tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -57,13 +57,17 @@ else
 TESTARGS =
 endif
 
+ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
+
 # Specific packages can be excluded from each of the tests below by setting the *_FILTER_CMD variables
 # to something like "| grep -v 'github.com/kubernetes-csi/project/pkg/foobar'". See usage below.
 
 build-%:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
-	CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$*
+	if [ "$$ARCH" = "amd64" ]; then \
+		CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$* ; \
+	fi
 
 container-%: build-%
 	docker build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) .
@@ -126,6 +130,26 @@ test-fmt:
 # - the fabricated merge commit leaves go.mod, go.sum and vendor dir unchanged
 # - release-tools also didn't change (changing rules or Go version might lead to
 #   a different result and thus must be tested)
+# - import statements not changed (because if they change, go.mod might have to be updated)
+#
+# "git diff" is intelligent enough to annotate changes inside the "import" block in
+# the start of the diff hunk:
+#
+# diff --git a/rpc/common.go b/rpc/common.go
+# index bb4a5c4..5fa4271 100644
+# --- a/rpc/common.go
+# +++ b/rpc/common.go
+# @@ -21,7 +21,6 @@ import (
+#         "fmt"
+#         "time"
+#
+# -       "google.golang.org/grpc"
+#         "google.golang.org/grpc/codes"
+#         "google.golang.org/grpc/status"
+#
+# We rely on that to find such changes.
+#
+# Vendoring is optional when using go.mod.
 .PHONY: test-vendor
 test: test-vendor
 test-vendor:
@@ -136,22 +160,37 @@ test-vendor:
 			*v0.[56789]*) dep check && echo "vendor up-to-date" || false;; \
 			*) echo "skipping check, dep >= 0.5 required";; \
 		esac; \
-	  else \
-		echo "Repo uses 'go mod' for vendoring."; \
+	elif [ -f go.mod ]; then \
+		echo "Repo uses 'go mod'."; \
 		if [ "$${JOB_NAME}" ] && \
                    ( [ "$${JOB_TYPE}" != "presubmit" ] || \
-                     [ $$(git diff "${PULL_BASE_SHA}..HEAD" -- go.mod go.sum vendor release-tools | wc -l) -eq 0 ] ); then \
-			echo "Skipping vendor check because the Prow pre-submit job does not change vendoring."; \
-		elif ! GO111MODULE=on go mod vendor; then \
+                     [ $$( (git diff "${PULL_BASE_SHA}..HEAD" -- go.mod go.sum vendor release-tools; \
+                            git diff "${PULL_BASE_SHA}..HEAD" | grep -e '^@@.*@@ import (' -e '^[+-]import') | \
+		          wc -l) -eq 0 ] ); then \
+			echo "Skipping vendor check because the Prow pre-submit job does not affect dependencies."; \
+		elif ! GO111MODULE=on go mod tidy; then \
 			echo "ERROR: vendor check failed."; \
 			false; \
-		elif [ $$(git status --porcelain -- vendor | wc -l) -gt 0 ]; then \
-			echo "ERROR: vendor directory *not* up-to-date, it did get modified by 'GO111MODULE=on go mod vendor':"; \
-			git status -- vendor; \
-			git diff -- vendor; \
+		elif [ $$(git status --porcelain -- go.mod go.sum | wc -l) -gt 0 ]; then \
+			echo "ERROR: go module files *not* up-to-date, they did get modified by 'GO111MODULE=on go mod tidy':"; \
+			git diff -- go.mod go.sum; \
 			false; \
+		elif [ -d vendor ]; then \
+			if ! GO111MODULE=on go mod vendor; then \
+				echo "ERROR: vendor check failed."; \
+				false; \
+			elif [ $$(git status --porcelain -- vendor | wc -l) -gt 0 ]; then \
+				echo "ERROR: vendor directory *not* up-to-date, it did get modified by 'GO111MODULE=on go mod vendor':"; \
+				git status -- vendor; \
+				git diff -- vendor; \
+				false; \
+			else \
+				echo "Go dependencies and vendor directory up-to-date."; \
+			fi; \
+		else \
+			echo "Go dependencies up-to-date."; \
 		fi; \
-	 fi;
+	fi
 
 .PHONY: test-subtree
 test: test-subtree

--- a/release-tools/go-get-kubernetes.sh
+++ b/release-tools/go-get-kubernetes.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script can be used while converting a repo from "dep" to "go mod"
+# by calling it after "go mod init" or to update the Kubernetes packages
+# in a repo that has already been converted. Only packages that are
+# part of kubernetes/kubernetes and thus part of a Kubernetes release
+# are modified. Other k8.io packages (like k8s.io/klog, k8s.io/utils)
+# need to be updated separately.
+
+set -o pipefail
+
+cmd=$0
+
+function help () {
+    echo "$cmd <kubernetes version = x.y.z> - update all components from kubernetes/kubernetes to that version"
+}
+
+if [ $# -ne 1 ]; then
+    help
+    exit 1
+fi
+case "$1" in -h|--help|help) help; exit 0;; esac
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+k8s="$1"
+
+# If the repo imports k8s.io/kubernetes (directly or indirectly), then
+# "go mod" will try to find "v0.0.0" versions because
+# k8s.io/kubernetes has those in it's go.mod file
+# (https://github.com/kubernetes/kubernetes/blob/2bd9643cee5b3b3a5ecbd3af49d09018f0773c77/go.mod#L146-L157).
+# (https://github.com/kubernetes/kubernetes/issues/79384).
+#
+# We need to replicate the replace statements to override those fake
+# versions also in our go.mod file (idea and some code from
+# https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-521493597).
+mods=$( (set -x; curl --silent --show-error --fail "https://raw.githubusercontent.com/kubernetes/kubernetes/v${k8s}/go.mod") |
+          sed -n 's|.*k8s.io/\(.*\) => ./staging/src/k8s.io/.*|k8s.io/\1|p'
+   ) || die "failed to determine Kubernetes staging modules"
+for mod in $mods; do
+    # The presence of a potentially incomplete go.mod file affects this command,
+    # so move elsewhere.
+    modinfo=$(set -x; cd /; env GO111MODULE=on go mod download -json "$mod@kubernetes-${k8s}") ||
+        die "failed to determine version of $mod: $modinfo"
+    v=$(echo "$modinfo" | sed -n 's|.*"Version": "\(.*\)".*|\1|p')
+    (set -x; env GO111MODULE=on go mod edit "-replace=$mod=$mod@$v") || die "'go mod edit' failed"
+done
+
+packages=
+
+# Beware that we have to work with packages, not modules (i.e. no -m
+# flag), because some modules trigger a "no Go code except tests"
+# error.  Getting their packages works.
+if ! packages=$( (set -x; env GO111MODULE=on go list all) | grep ^k8s.io/ | sed -e 's; *;;'); then
+    cat >&2 <<EOF
+
+Warning: "GO111MODULE=on go list all" failed, trying individual packages instead.
+
+EOF
+    if ! packages=$( (set -x; env GO111MODULE=on go list -f '{{ join .Deps "\n" }}' ./...) | grep ^k8s.io/); then
+        cat >&2 <<EOF
+
+ERROR: could not obtain package list, both of these commands failed:
+       GO111MODULE=on go list all
+       GO111MODULE=on go list -f '{{ join .Deps "\n" }}' ./pkg/...
+EOF
+        exit 1
+    fi
+fi
+
+deps=
+for package in $packages; do
+    # Some k8s.io packages do not come from Kubernetes staging and
+    # thus have different versioning (or none at all...). We need to
+    # skip those.  We know what packages are from staging because we
+    # now have "replace" statements for them in go.mod.
+    #
+    # shellcheck disable=SC2001
+    module=$(echo "$package" | sed -e 's;k8s.io/\([^/]*\)/.*;k8s.io/\1;')
+    if grep -q -w "$module *=>" go.mod; then
+        deps="$deps $(echo "$package" | sed -e "s;\$;@kubernetes-$k8s;" -e 's;^k8s.io/kubernetes\(/.*\)@kubernetes-;k8s.io/kubernetes\1@v;')"
+    fi
+done
+
+# shellcheck disable=SC2086
+(set -x; env GO111MODULE=on go get $deps 2>&1) || die "go get failed"
+echo "SUCCESS"

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -183,7 +183,7 @@ configvar CSI_PROW_WORK "$(mkdir -p "$GOPATH/pkg" && mktemp -d "$GOPATH/pkg/csip
 #
 # When no deploy script is found (nothing in `deploy` directory,
 # CSI_PROW_HOSTPATH_REPO=none), nothing gets deployed.
-configvar CSI_PROW_HOSTPATH_VERSION "v1.2.0-rc2" "hostpath driver"
+configvar CSI_PROW_HOSTPATH_VERSION "v1.2.0-rc8" "hostpath driver"
 configvar CSI_PROW_HOSTPATH_REPO https://github.com/kubernetes-csi/csi-driver-host-path "hostpath repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_HOSTPATH_DRIVER_NAME "hostpath.csi.k8s.io" "the hostpath driver name"
@@ -759,6 +759,8 @@ DriverInfo:
     persistence: true
     dataSource: true
     multipods: true
+    nodeExpansion: true
+    controllerExpansion: true
 EOF
 }
 

--- a/release-tools/travis.yml
+++ b/release-tools/travis.yml
@@ -2,6 +2,8 @@ language: go
 sudo: required
 services:
   - docker
+git:
+  depth: false
 matrix:
   include:
   - go: 1.12.4


### PR DESCRIPTION
Update release tools to current master to fix builds on non-amd64 architectures.

From other features available in new release-tools:
* Update Go mod support
* Enable hostpath expansion in e2e tests

/kind cleanup

```release-note
NONE
```