### PR TITLE
Remove registratation socket file on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ the actual driver's name.
           args:
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/<drivername.example.com>/csi.sock"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/<plugin> /registration/<drivername.example.com>-reg.sock"]
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/cmd/csi-node-driver-registrar/node_register.go
+++ b/cmd/csi-node-driver-registrar/node_register.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/signal"
 	"runtime"
+	"syscall"
 
 	"google.golang.org/grpc"
 
@@ -36,7 +38,7 @@ func nodeRegister(
 	// as gRPC server which replies to registration requests initiated by kubelet's
 	// pluginswatcher infrastructure. Node labeling is done by kubelet's csi code.
 	registrar := newRegistrationServer(csiDriverName, *kubeletRegistrationPath, supportedVersions)
-	socketPath := fmt.Sprintf("/registration/%s-reg.sock", csiDriverName)
+	socketPath := buildSocketPath(csiDriverName)
 	if err := util.CleanupSocketFile(socketPath); err != nil {
 		klog.Errorf("%+v", err)
 		os.Exit(1)
@@ -62,11 +64,29 @@ func nodeRegister(
 	// Registers kubelet plugin watcher api.
 	registerapi.RegisterRegistrationServer(grpcServer, registrar)
 
+	go removeRegSocket(csiDriverName)
 	// Starts service
 	if err := grpcServer.Serve(lis); err != nil {
 		klog.Errorf("Registration Server stopped serving: %v", err)
 		os.Exit(1)
 	}
 	// If gRPC server is gracefully shutdown, exit
+	os.Exit(0)
+}
+
+func buildSocketPath(csiDriverName string) string {
+	return fmt.Sprintf("/registration/%s-reg.sock", csiDriverName)
+}
+
+func removeRegSocket(csiDriverName string) {
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGTERM)
+	<-sigc
+	socketPath := buildSocketPath(csiDriverName)
+	err := os.Remove(socketPath)
+	if err != nil && !os.IsNotExist(err) {
+		klog.Errorf("failed to remove socket: %s with error: %+v", socketPath, err)
+		os.Exit(1)
+	}
 	os.Exit(0)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

when terminating, remove the *-reg.socket file created by node-driver-registrar

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #21

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
