### PR TITLE
[WIP] Support for multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
+#export DOCKER_CLI_EXPERIMENTAL=enabled
+#docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
+#docker buildx create --use --name mybuilder
+#docker buildx build -t colek42/csi-node-driver-registrar --platform=linux/arm,linux/arm64,linux/amd64 . --push
+
+FROM golang:1.13 as builder
+WORKDIR /app
+ADD . /app/
+RUN make
+
 FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI Node driver registrar"
 
-COPY ./bin/csi-node-driver-registrar csi-node-driver-registrar
+COPY --from=builder /app/bin/csi-node-driver-registrar csi-node-driver-registrar
 ENTRYPOINT ["/csi-node-driver-registrar"]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Support CSI on multiple arch

**Special notes for your reviewer**:
I am proposing that we move the build logic out of the makefile and into the multi-stage Dockerfile.  This will help us support multiple archtectures easily using `docker buildx` and ensure the build environment is reproducable.

This PR is a POC on how that may work.  Additional changes to the build process will be required.  See https://hub.docker.com/r/colek42/csi-node-driver-registrar/tags for the built images

ref: #55 #48 

**Does this PR introduce a user-facing change?**:
```release-note
Add multi-arch image support
```


