### PR TITLE
feat(Dockerfile.Windows): Streamline building windows image by building the exe in a builder image stage

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,9 +1,25 @@
-FROM mcr.microsoft.com/windows/servercore:1809 as core
+# Other common ones: 1803-amd64, 1903-amd64
+# full list: curl -L https://mcr.microsoft.com/v2/windows/nanoserver/tags/list
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+ARG golangTag=1.12.6-windowsservercore-1809
+ARG nanoserverTag="mcr.microsoft.com/windows/nanoserver:1809"
+ARG servercoreTag="mcr.microsoft.com/windows/servercore:1809"
+ARG goflags_vendor=""
+ARG buildVersion=""
+
+FROM golang:${golangTag} as builder
+ENV SRC_PATH="src/github.com/kubernetes-csi/node-driver-registrar"
+COPY . ${SRC_PATH}
+RUN cd $ENV:SRC_PATH ; go build ${goflags_vendor} -a -ldflags '-X main.version=${buildVersion} -extldflags "-static"' -o ./bin/csi-node-driver-registrar.exe ./cmd/csi-node-driver-registrar ; ls ./bin ;
+
+
+FROM ${servercoreTag} as core
+
+
+FROM ${nanoserverTag}
 LABEL description="CSI Node driver registrar"
-
-COPY ./bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
+# COPY ./bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
+COPY --from=builder gopath/src/github.com/kubernetes-csi/node-driver-registrar/bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
 USER ContainerAdministrator
 ENTRYPOINT ["/csi-node-driver-registrar.exe"]

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,7 +1,7 @@
 # Other common ones: 1803-amd64, 1903-amd64
 # full list: curl -L https://mcr.microsoft.com/v2/windows/nanoserver/tags/list
 
-ARG golangTag=1.12.6-windowsservercore-1809
+ARG golangTag=1.14.0-windowsservercore-1809
 ARG nanoserverTag="mcr.microsoft.com/windows/nanoserver:1809"
 ARG servercoreTag="mcr.microsoft.com/windows/servercore:1809"
 ARG goflags_vendor=""

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -18,7 +18,6 @@ FROM ${servercoreTag} as core
 
 FROM ${nanoserverTag}
 LABEL description="CSI Node driver registrar"
-# COPY ./bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 COPY --from=builder gopath/src/github.com/kubernetes-csi/node-driver-registrar/bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe
 USER ContainerAdministrator

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,7 +1,7 @@
 # Other common ones: 1803-amd64, 1903-amd64
 # full list: curl -L https://mcr.microsoft.com/v2/windows/nanoserver/tags/list
 
-ARG golangTag=1.14.0-windowsservercore-1809
+ARG golangTag=1.13.3-windowsservercore-1809
 ARG nanoserverTag="mcr.microsoft.com/windows/nanoserver:1809"
 ARG servercoreTag="mcr.microsoft.com/windows/servercore:1809"
 ARG goflags_vendor=""


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Creates a builder stage image which is used to produce the exe file before building the main Windows image. This allows easier integration into CI systems for producing windows images. Also parameterizes the images so we can easily churn out multiple images for different windows versions. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
