### PR TITLE
Multiarch Docker Image support using GCB

### DIFF
--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,0 +1,14 @@
+FROM --platform=$BUILDPLATFORM golang:1.13.3 AS builder
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+WORKDIR /code
+ADD . /code/
+
+RUN cd /code/ && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make build
+
+FROM gcr.io/distroless/static:latest
+LABEL maintainers="Kubernetes Authors"
+LABEL description="CSI Node driver registrar"
+
+COPY --from=builder /code/bin/csi-node-driver-registrar csi-node-driver-registrar
+ENTRYPOINT ["/csi-node-driver-registrar"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,28 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: 'bash'
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - '-c'
+    - |
+      docker buildx create --use --name multiarchimage-builder \
+      && docker buildx build --push -t gcr.io/k8s-staging-csi/csi-node-driver-registrar:latest --platform=linux/amd64,linux/s390x -f Dockerfile.multiarch .
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# See https://cloud.google.com/cloud-build/docs/build-config
+# See https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md for more details on image pushing process
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
 timeout: 1200s


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
This is continuation with comment https://github.com/kubernetes-csi/node-driver-registrar/pull/67#issuecomment-602740861 
Add a GCB(Google Cloud Build) configuration file and Dockerfile.multiarch. This will automate the building and pushing of node-driver-registrar multiarch image to staging area(gcr.io/k8s-staging-csi)

@pohly can you please review ?