### PR TITLE
build both platforms and generate manifest as well

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,8 +18,16 @@ steps:
     - '-c'
     - |
       export DOCKER_CLI_EXPERIMENTAL=enabled \
+      && gcloud auth configure-docker \
       && docker buildx create --use --name multiarchimage-builder \
-      && docker buildx build --push -t gcr.io/k8s-staging-csi/csi-node-driver-registrar:latest --platform=linux/amd64,linux/s390x -f Dockerfile.multiarch .
+      && docker buildx build --load -t gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-$_GIT_TAG --platform=linux/amd64 -f Dockerfile.multiarch . \
+      && docker push gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-$_GIT_TAG \
+      && docker buildx build --load -t gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-$_GIT_TAG --platform=linux/s390x -f Dockerfile.multiarch . \
+      && docker push gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-$_GIT_TAG \
+      && docker manifest create --amend gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:$_GIT_TAG \
+        gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-$_GIT_TAG \
+        gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-$_GIT_TAG \
+      && docker manifest push -p gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:$_GIT_TAG
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
@@ -27,4 +35,4 @@ substitutions:
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'master'
-
+  _STAGING_PROJECT: 'k8s-staging-csi'


### PR DESCRIPTION
Tested locally using the following command line (`kubernetes-development-244305` is my own sandbox)
```
gcloud builds submit --config cloudbuild.yaml --substitutions=_STAGING_PROJECT=kubernetes-development-244305 .
```

Notes:
- We need to build each platform separately (`docker buildx build`) 
- We load the image using `--load` into the docker daemon (buildx loads this up when we specify --load)
- We push each image to gcr.io
- THEN we use `docker manifest create` to create the manifest
- Finally we push the manifest using `docker manifest push`

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
