### PR TITLE
Fix to exec format error on non-intel arch

### DIFF
--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -4,7 +4,7 @@ ARG BUILDPLATFORM
 WORKDIR /code
 ADD . /code/
 
-RUN cd /code/ && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make build
+RUN cd /code/ && make BUILD_PLATFORMS="linux $(echo $TARGETPLATFORM | cut -f2 -d '/')"
 
 FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
This PR fixes `exec format error`  observed on s390x image which is built using `Dockerfile.multiarch`  

@pohly could you please review ?