### PR TITLE
Add build step for Windows container image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,13 +20,14 @@ steps:
       export DOCKER_CLI_EXPERIMENTAL=enabled \
       && gcloud auth configure-docker \
       && docker buildx create --use --name multiarchimage-builder \
-      && docker buildx build --load -t gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-$_GIT_TAG --platform=linux/amd64 -f Dockerfile.multiarch . \
-      && docker push gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-$_GIT_TAG \
-      && docker buildx build --load -t gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-$_GIT_TAG --platform=linux/s390x -f Dockerfile.multiarch . \
-      && docker push gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-$_GIT_TAG \
+      && docker buildx build --push -t gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-linux-$_GIT_TAG --platform=linux/amd64 -f Dockerfile.multiarch . \
+      && docker buildx build --push -t gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-linux-$_GIT_TAG --platform=linux/s390x -f Dockerfile.multiarch . \
+      && make BUILD_PLATFORMS="windows amd64 .exe" \
+      && docker buildx build --push -t gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-windows-$_GIT_TAG --platform=windows -f Dockerfile.Windows . \
       && docker manifest create --amend gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:$_GIT_TAG \
-        gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-$_GIT_TAG \
-        gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-$_GIT_TAG \
+        gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-linux-$_GIT_TAG \
+        gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:s390x-linux-$_GIT_TAG \
+        gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:amd64-windows-$_GIT_TAG \
       && docker manifest push -p gcr.io/$_STAGING_PROJECT/csi-node-driver-registrar:$_GIT_TAG
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and


### PR DESCRIPTION
Use buildx to build windows container image and push it to registry

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
