### PR TITLE
cloud build: fix shell syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ push-multiarch-%: check-pull-base-ref build-%
 		       pushMultiArch $(PULL_BASE_REF); \
 	else \
 			: "ERROR: release image $(IMAGE_NAME):$(PULL_BASE_REF) already exists: a new tag is required!"; \
-			exit 1
+			exit 1; \
 	fi; \
 
 .PHONY: check-pull-base-ref


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

A last-minute change in https://github.com/kubernetes-csi/node-driver-registrar/pull/84 was not correct.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
