### PR TITLE
Add flag to configure the registration socket path

### DIFF
--- a/cmd/csi-node-driver-registrar/main.go
+++ b/cmd/csi-node-driver-registrar/main.go
@@ -46,6 +46,7 @@ const (
 var (
 	connectionTimeout       = flag.Duration("connection-timeout", 0, "The --connection-timeout flag is deprecated")
 	csiAddress              = flag.String("csi-address", "/run/csi/socket", "Path of the CSI driver socket that the node-driver-registrar will connect to.")
+	pluginRegistrationPath  = flag.String("plugin-registration-path", "/registration", "Path to Kubernetes plugin registration directory.")
 	kubeletRegistrationPath = flag.String("kubelet-registration-path", "", "Path of the CSI driver socket on the Kubernetes host machine.")
 	showVersion             = flag.Bool("version", false, "Show version.")
 	version                 = "unknown"

--- a/cmd/csi-node-driver-registrar/node_register.go
+++ b/cmd/csi-node-driver-registrar/node_register.go
@@ -75,7 +75,7 @@ func nodeRegister(
 }
 
 func buildSocketPath(csiDriverName string) string {
-	return fmt.Sprintf("/registration/%s-reg.sock", csiDriverName)
+	return fmt.Sprintf("%s/%s-reg.sock", *pluginRegistrationPath, csiDriverName)
 }
 
 func removeRegSocket(csiDriverName string) {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
adds support to dynamically configure the registration socket path via a `plugin-registration-path` flag 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
the addition of the --plugin-registration-path flag allows users to dynamically configure the registration path; this flag defaults to the currently hardcoded value of `/registration` so actions can be taken to consume this change but is not required
```
