### PR TITLE
HTTP server for liveness probe, check registration socket exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ There are two UNIX domain sockets used by the node-driver-registrar:
   `/var/lib/kubelet/plugins/<drivername.example.com>/csi.sock). Note this is NOT
   the path to the registration socket.
 
+### Optional arguments
+
+* `--health-port`: This is the port of the health check server for the node-driver-registrar,
+  which checks if the registration socket exists. A value <= 0 disables the server.
+  Server is disabled by default.
+
 ### Required permissions
 
 The node-driver-registrar does not interact with the Kubernetes API, so no RBAC
@@ -76,11 +82,21 @@ the actual driver's name.
           args:
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/<drivername.example.com>/csi.sock"
+            - "--health-port=9809"
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          ports:
+            - containerPort: 9809
+              name: healthz
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
       volumes:
         - name: registration-dir
           hostPath:

--- a/cmd/csi-node-driver-registrar/main.go
+++ b/cmd/csi-node-driver-registrar/main.go
@@ -47,6 +47,7 @@ var (
 	connectionTimeout       = flag.Duration("connection-timeout", 0, "The --connection-timeout flag is deprecated")
 	csiAddress              = flag.String("csi-address", "/run/csi/socket", "Path of the CSI driver socket that the node-driver-registrar will connect to.")
 	kubeletRegistrationPath = flag.String("kubelet-registration-path", "", "Path of the CSI driver socket on the Kubernetes host machine.")
+	healthzPort             = flag.Int("health-port", 0, "TCP port for healthz requests. Set to 0 to disable the healthz server.")
 	showVersion             = flag.Bool("version", false, "Show version.")
 	version                 = "unknown"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a liveness probe server that monitors the existence of the registration socket. Included are refactors to reduce code duplication checking for socket exists. Note that there are behavioral differences in how linux and windows systems check for sockets, see the bug in comments below.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #57 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds a new flag --health-port. This is the port of the health check server for the node-driver-registrar, which checks if the registration socket exists. A value <= 0 disables the server. Server is disabled by default.
```
