### PR TITLE
Cherry-pick of 108: Update image and tag parameter for Dockerfile.Windows

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,9 +1,11 @@
-ARG BASE_IMAGE=servercore
-ARG BASE_IMAGE_TAG=1809
+ARG CORE_IMAGE=servercore
+ARG CORE_IMAGE_TAG=1809
+ARG BUILD_IMAGE=nanoserver
+ARG BUILD_IMAGE_TAG=1809
 ARG REGISTRY=mcr.microsoft.com/windows
 
-FROM ${REGISTRY}/${BASE_IMAGE}:${BASE_IMAGE_TAG} as core
-FROM mcr.microsoft.com/windows/nanoserver:${BASE_IMAGE_TAG}
+FROM ${REGISTRY}/${CORE_IMAGE}:${CORE_IMAGE_TAG} as core
+FROM ${REGISTRY}/${BUILD_IMAGE}:${BUILD_IMAGE_TAG}
 LABEL description="CSI Node driver registrar"
 
 COPY ./bin/csi-node-driver-registrar.exe /csi-node-driver-registrar.exe


### PR DESCRIPTION
Dockerfile.Windows has two container images, servercore and nanoserver,
use seperate parameter for them.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update image and tag names for Windows to have separate parameters for nanoserver and servercore
```
