### PR TITLE
Update release-tools

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -330,7 +330,14 @@ configvar CSI_PROW_E2E_ALPHA_GATES_LATEST 'GenericEphemeralVolume=true,CSIStorag
 configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_GATES "${csi_prow_kubernetes_version_suffix}")" "alpha E2E feature gates"
 
 # Which external-snapshotter tag to use for the snapshotter CRD and snapshot-controller deployment
-configvar CSI_SNAPSHOTTER_VERSION 'v3.0.0' "external-snapshotter version tag"
+default_csi_snapshotter_version () {
+	if [ "${CSI_PROW_KUBERNETES_VERSION}" = "latest" ] || [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
+		echo "master"
+	else
+		echo "v3.0.2"
+	fi
+}
+configvar CSI_SNAPSHOTTER_VERSION "$(default_csi_snapshotter_version)" "external-snapshotter version tag"
 
 # Some tests are known to be unusable in a KinD cluster. For example,
 # stopping kubelet with "ssh <node IP> systemctl stop kubelet" simply


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Squashed 'release-tools/' changes from 4aff857d..5d874cce

5d874cce Merge pull request #112 from xing-yang/cleanup
79bbca7b Cleanup
d4376730 Merge pull request #111 from xing-yang/update_snapshot_v1_rc
57718f83 Update snapshot CRD version

git-subtree-dir: release-tools
git-subtree-split: 5d874cce4e649dfd254d01b9b44179ffa72aee75

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
