### PR TITLE
add --timeout for gRPC calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ There are two UNIX domain sockets used by the node-driver-registrar:
   node-driver-registrar, which checks if the registration socket exists. A value <= 0 disables
   the server. Server is disabled by default.
 
+* `--timeout <duration>`: Timeout of all calls to CSI driver. It should be set to a value that accommodates the `GetDriverName` calls. 1 second is used by default.
+
 ### Required permissions
 
 The node-driver-registrar does not interact with the Kubernetes API, so no RBAC

--- a/cmd/csi-node-driver-registrar/main.go
+++ b/cmd/csi-node-driver-registrar/main.go
@@ -37,9 +37,6 @@ const (
 	// names
 	annotationKey = "csi.volume.kubernetes.io/nodeid"
 
-	// Default timeout of short CSI calls like GetPluginInfo
-	csiTimeout = time.Second
-
 	// Verify (and update, if needed) the node ID at this frequency.
 	sleepDuration = 2 * time.Minute
 )
@@ -47,6 +44,7 @@ const (
 // Command line flags
 var (
 	connectionTimeout       = flag.Duration("connection-timeout", 0, "The --connection-timeout flag is deprecated")
+	operationTimeout        = flag.Duration("timeout", time.Second, "Timeout for waiting for communication with driver")
 	csiAddress              = flag.String("csi-address", "/run/csi/socket", "Path of the CSI driver socket that the node-driver-registrar will connect to.")
 	pluginRegistrationPath  = flag.String("plugin-registration-path", "/registration", "Path to Kubernetes plugin registration directory.")
 	kubeletRegistrationPath = flag.String("kubelet-registration-path", "", "Path of the CSI driver socket on the Kubernetes host machine.")
@@ -144,7 +142,7 @@ func main() {
 	}
 
 	klog.V(1).Infof("Calling CSI driver to discover driver name")
-	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), *operationTimeout)
 	defer cancel()
 
 	csiDriverName, err := csirpc.GetDriverName(ctx, csiConn)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

The one second timeout is based on the assumption that once the
connection is established, all further communication is going to be
fast.

That assumption doesn't hold in some special circumstances:
- interactively debugging the sidecar
- proxying the driver operation to some remote implementation

While this is a bit obscure, the flag is essential for these
cases. Adding the flag also makes the node-driver-registrar consistent
with other sidecars.

**Special notes for your reviewer**:

I have a prototype working with the mock driver embedded inside the e2e.test binary (the "proxying operation" case). I'll share more details after completing that work. In the meantime it would be good to get this PR included in the next release for Kubernetes 1.20.

**Does this PR introduce a user-facing change?**:
```release-note
added --timeout parameter for the unlikely case that a driver's GetPluginInfo call is slower than one second
```
