### PR TITLE
Introduce http-endpoint flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ There are two UNIX domain sockets used by the node-driver-registrar:
 
 ### Optional arguments
 
-* `--health-port`: This is the port of the health check server for the node-driver-registrar,
-  which checks if the registration socket exists. A value <= 0 disables the server.
-  Server is disabled by default.
+* `--http-endpoint`: "The TCP network address where the HTTP server for diagnostics, including
+  the health check indicating whether the registration socket exists, will listen (example:
+  `:8080`). The default is empty string, which means the server is disabled.
+
+* `--health-port`: (deprecated) This is the port of the health check server for the
+  node-driver-registrar, which checks if the registration socket exists. A value <= 0 disables
+  the server. Server is disabled by default.
 
 ### Required permissions
 
@@ -69,6 +73,11 @@ permissions to:
     contain (via the CSI `GetPluginInfo()` call).
 * Access the registration socket (typically in `/var/lib/kubelet/plugins_registry/`).
   * Used by the `node-driver-registrar` to register the driver with kubelet.
+
+### Health Check
+
+If `--http-endpoint` is set, the node-driver-registrar exposes a health check endpoint at the
+specified address and the path `/healthz`, indicating whether the registration socket exists.
 
 ### Example
 

--- a/cmd/csi-node-driver-registrar/node_register.go
+++ b/cmd/csi-node-driver-registrar/node_register.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"strconv"
 	"syscall"
 
 	"google.golang.org/grpc"
@@ -33,9 +32,7 @@ import (
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 )
 
-func nodeRegister(
-	csiDriverName string,
-) {
+func nodeRegister(csiDriverName, httpEndpoint string) {
 	// When kubeletRegistrationPath is specified then driver-registrar ONLY acts
 	// as gRPC server which replies to registration requests initiated by kubelet's
 	// pluginswatcher infrastructure. Node labeling is done by kubelet's csi code.
@@ -66,7 +63,7 @@ func nodeRegister(
 	// Registers kubelet plugin watcher api.
 	registerapi.RegisterRegistrationServer(grpcServer, registrar)
 
-	go healthzServer(socketPath, *healthzPort)
+	go healthzServer(socketPath, httpEndpoint)
 	go removeRegSocket(csiDriverName)
 	// Starts service
 	if err := grpcServer.Serve(lis); err != nil {
@@ -81,12 +78,12 @@ func buildSocketPath(csiDriverName string) string {
 	return fmt.Sprintf("%s/%s-reg.sock", *pluginRegistrationPath, csiDriverName)
 }
 
-func healthzServer(socketPath string, port int) {
-	if port <= 0 {
-		klog.Infof("Skipping healthz server because port set to: %v", port)
+func healthzServer(socketPath string, httpEndpoint string) {
+	if httpEndpoint == "" {
+		klog.Infof("Skipping healthz server because HTTP endpoint is set to: %q", httpEndpoint)
 		return
 	}
-	klog.Infof("Starting healthz server on port: %v\n", port)
+	klog.Infof("Starting healthz server at HTTP endpoint: %v\n", httpEndpoint)
 
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
 		socketExists, err := util.DoesSocketExist(socketPath)
@@ -105,7 +102,7 @@ func healthzServer(socketPath string, port int) {
 		}
 	})
 
-	klog.Fatal(http.ListenAndServe(":"+strconv.Itoa(port), nil))
+	klog.Fatal(http.ListenAndServe(httpEndpoint, nil))
 }
 
 func removeRegSocket(csiDriverName string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Introduces the `http-endpoint` flag as the main HTTP server endpoint, to align with other sidecars. See https://github.com/kubernetes-csi/external-provisioner/pull/537 as an example.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`health-port` flag is deprecated and replaced by `http-endpoint`.
```

/assign @chrishenzie @msau42 