### PR TITLE
release-2.4: update release-tools

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64; linux ppc64le -ppc64le; linux s
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.16" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.17.3" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
Squashed 'release-tools/' changes from 5b9a1e06..a6a1a797

[a6a1a797](https://github.com/kubernetes-csi/csi-release-tools/commit/a6a1a797) Merge [pull request #176](https://github.com/kubernetes-csi/csi-release-tools/pull/176) from pohly/go-1.17.3
[0a2cf636](https://github.com/kubernetes-csi/csi-release-tools/commit/0a2cf636) prow.sh: bump Go to 1.17.3
[fc29fdde](https://github.com/kubernetes-csi/csi-release-tools/commit/fc29fdde) Merge [pull request #141](https://github.com/kubernetes-csi/csi-release-tools/pull/141) from pohly/prune-replace-optional
[b46691a4](https://github.com/kubernetes-csi/csi-release-tools/commit/b46691a4) go-get-kubernetes.sh: make replace statement pruning optional

git-subtree-dir: release-tools
git-subtree-split: a6a1a7979bf3ebc2bb10d0e33dd11ab281d6d39e

```release-note
NONE
```