### PR TITLE
Automated cherry pick of #190: Correct the handler used in serving http requests

### DIFF
--- a/cmd/csi-node-driver-registrar/node_register.go
+++ b/cmd/csi-node-driver-registrar/node_register.go
@@ -123,7 +123,7 @@ func httpServer(socketPath string, httpEndpoint string) {
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
 
-	klog.Fatal(http.ListenAndServe(httpEndpoint, nil))
+	klog.Fatal(http.ListenAndServe(httpEndpoint, mux))
 }
 
 func removeRegSocket(csiDriverName string) {


### PR DESCRIPTION
Cherry pick of #190 on release-2.5.

#190: Correct the handler used in serving http requests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Corrects the handler used to serve http requests, the /healthz and /debug/ endpoints are available now.
```