### PR TITLE
Remove mkdir call while creating the registration probe file

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 var socketFileName = "reg.sock"
-var kubeletRegistrationPath = "/var/lib/kubelet/plugins/csi-dummy/registration"
 
 // TestSocketFileDoesNotExist - Test1: file does not exist. So clean up should be successful.
 func TestSocketFileDoesNotExist(t *testing.T) {
@@ -184,7 +183,9 @@ func TestTouchFile(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	filePath := filepath.Join(testDir, kubeletRegistrationPath)
+	// In real life, testDir would be the kubeletRegistration socket dirname
+	// e.g. /var/lib/kubelet/plugins/<driver>/
+	filePath := filepath.Join(testDir, "registration")
 	fileExists, err := DoesFileExist(filePath)
 	if err != nil {
 		t.Fatalf("Failed to execute file exist: %+v", err)

--- a/pkg/util/util_unix.go
+++ b/pkg/util/util_unix.go
@@ -22,7 +22,6 @@ package util
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -88,11 +87,6 @@ func TouchFile(filePath string) error {
 		return err
 	}
 	if !exists {
-		err := os.MkdirAll(filepath.Dir(filePath), 0755)
-		if err != nil {
-			return err
-		}
-
 		file, err := os.Create(filePath)
 		if err != nil {
 			return err

--- a/pkg/util/util_windows.go
+++ b/pkg/util/util_windows.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 )
 
 func Umask(mask int) (int, error) {
@@ -86,11 +85,6 @@ func TouchFile(filePath string) error {
 		return err
 	}
 	if !exists {
-		err := os.MkdirAll(filepath.Dir(filePath), 0755)
-		if err != nil {
-			return err
-		}
-
 		file, err := os.Create(filePath)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

**What this PR does / why we need it**:
node-driver-registrar fails to come up on a filesystem where the `/var/lib/kubelet` directory is read only

Under the assumption that the `kubeletRegistrationPath` path exists we don't need to create subdirectories, we will still create the probe exec file by default though.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #213

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The directories in `kubeletRegistrationPath` are assumed to be already created and are no longer created by node-driver-registrar
```

/cc @jingxu97 @msau42 