### PR TITLE
Revert "Remove mkdir call while creating the registration probe file"

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 var socketFileName = "reg.sock"
+var kubeletRegistrationPath = "/var/lib/kubelet/plugins/csi-dummy/registration"
 
 // TestSocketFileDoesNotExist - Test1: file does not exist. So clean up should be successful.
 func TestSocketFileDoesNotExist(t *testing.T) {
@@ -183,9 +184,7 @@ func TestTouchFile(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	// In real life, testDir would be the kubeletRegistration socket dirname
-	// e.g. /var/lib/kubelet/plugins/<driver>/
-	filePath := filepath.Join(testDir, "registration")
+	filePath := filepath.Join(testDir, kubeletRegistrationPath)
 	fileExists, err := DoesFileExist(filePath)
 	if err != nil {
 		t.Fatalf("Failed to execute file exist: %+v", err)

--- a/pkg/util/util_unix.go
+++ b/pkg/util/util_unix.go
@@ -22,6 +22,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -87,6 +88,11 @@ func TouchFile(filePath string) error {
 		return err
 	}
 	if !exists {
+		err := os.MkdirAll(filepath.Dir(filePath), 0755)
+		if err != nil {
+			return err
+		}
+
 		file, err := os.Create(filePath)
 		if err != nil {
 			return err

--- a/pkg/util/util_windows.go
+++ b/pkg/util/util_windows.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func Umask(mask int) (int, error) {
@@ -85,6 +86,11 @@ func TouchFile(filePath string) error {
 		return err
 	}
 	if !exists {
+		err := os.MkdirAll(filepath.Dir(filePath), 0755)
+		if err != nil {
+			return err
+		}
+
 		file, err := os.Create(filePath)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
#214 created a bug described in https://github.com/kubernetes-csi/node-driver-registrar/issues/244, the assumption that I made that `/var/lib/kubelet/plugins/<drivername.example.com>/` is created beforehand is valid but it's mapped to `/csi` in the container, the container later refers to `/var/lib/kubelet/plugins/<drivername.example.com>/csi.sock` which is a new path inside the container and therefore it doesn't exist.

With that in mind, we should still create the path `/var/lib/kubelet/plugins/<drivername.example.com>/` inside the container.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #244, reopens #213

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Revert of #214, node-driver-registrar will create the path specified by `--kubelet-registration-path`
```

/cc @jingxu97 @msau42 