### PR TITLE
Automated cherry pick of #247: Revert "Remove mkdir call while creating the registration

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 var socketFileName = "reg.sock"
+var kubeletRegistrationPath = "/var/lib/kubelet/plugins/csi-dummy/registration"
 
 // TestSocketFileDoesNotExist - Test1: file does not exist. So clean up should be successful.
 func TestSocketFileDoesNotExist(t *testing.T) {
@@ -183,9 +184,7 @@ func TestTouchFile(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	// In real life, testDir would be the kubeletRegistration socket dirname
-	// e.g. /var/lib/kubelet/plugins/<driver>/
-	filePath := filepath.Join(testDir, "registration")
+	filePath := filepath.Join(testDir, kubeletRegistrationPath)
 	fileExists, err := DoesFileExist(filePath)
 	if err != nil {
 		t.Fatalf("Failed to execute file exist: %+v", err)

--- a/pkg/util/util_unix.go
+++ b/pkg/util/util_unix.go
@@ -22,6 +22,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -87,6 +88,11 @@ func TouchFile(filePath string) error {
 		return err
 	}
 	if !exists {
+		err := os.MkdirAll(filepath.Dir(filePath), 0755)
+		if err != nil {
+			return err
+		}
+
 		file, err := os.Create(filePath)
 		if err != nil {
 			return err

--- a/pkg/util/util_windows.go
+++ b/pkg/util/util_windows.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func Umask(mask int) (int, error) {
@@ -85,6 +86,11 @@ func TouchFile(filePath string) error {
 		return err
 	}
 	if !exists {
+		err := os.MkdirAll(filepath.Dir(filePath), 0755)
+		if err != nil {
+			return err
+		}
+
 		file, err := os.Create(filePath)
 		if err != nil {
 			return err


### PR DESCRIPTION
Cherry pick of #247 on release-2.6.

#247: Revert "Remove mkdir call while creating the registration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Revert of #214, node-driver-registrar will create the path specified by `--kubelet-registration-path`
```