### PR TITLE
Update dependabot.yaml for security updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,39 +10,6 @@ updates:
     - "ok-to-test"
   open-pull-requests-limit: 10
 
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 0
-  target-branch: "release-2.6"
-
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 0
-  target-branch: "release-2.7"
-
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 0
-  target-branch: "release-2.8"
-
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -52,4 +19,40 @@ updates:
     - "release-note-none"
     - "ok-to-test"
   open-pull-requests-limit: 10
+
+# The list below needs to be maintained manually with every branch we support.
+# It allows dependabot to open security-only updates in supported branches.
+# ("open-pull-requests-limit: 0" blocks non-security updates)
+- package-ecosystem: gomod
+  open-pull-requests-limit: 0
+  target-branch: "release-2.6"
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+
+- package-ecosystem: gomod
+  open-pull-requests-limit: 0
+  target-branch: "release-2.7"
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+
+- package-ecosystem: gomod
+  open-pull-requests-limit: 0
+  target-branch: "release-2.8"
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,40 @@ updates:
     - "release-note-none"
     - "ok-to-test"
   open-pull-requests-limit: 10
+
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 0
+  target-branch: "release-2.6"
+
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 0
+  target-branch: "release-2.7"
+
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 0
+  target-branch: "release-2.8"
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -18,3 +52,4 @@ updates:
     - "release-note-none"
     - "ok-to-test"
   open-pull-requests-limit: 10
+


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Testing if dependabot can create security pull request for release-2.6, 2.7 and 2.8 branches.

I am trying to cheat with a separate `updates` entry per branch. 

Most likely this will not work, dependabot cannot bump only security-relevan dependencies in older branches, see  https://github.com/dependabot/dependabot-core/issues/2767#issuecomment-1325799552

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
