### PR TITLE
Update dependabot.yaml for security updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -18,3 +9,49 @@ updates:
     - "release-note-none"
     - "ok-to-test"
   open-pull-requests-limit: 10
+
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+
+# The list below needs to be maintained manually with every branch we support.
+# It allows dependabot to open security-only updates in supported branches.
+# ("open-pull-requests-limit: 0" blocks non-security updates)
+- package-ecosystem: gomod
+  open-pull-requests-limit: 0
+  target-branch: "release-2.6"
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+
+- package-ecosystem: gomod
+  open-pull-requests-limit: 0
+  target-branch: "release-2.7"
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+
+- package-ecosystem: gomod
+  open-pull-requests-limit: 0
+  target-branch: "release-2.8"
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is continuation of https://github.com/kubernetes-csi/node-driver-registrar/pull/301.

Testing if dependabot can create security pull request for release-2.6, 2.7 and 2.8 branches.

I am trying to cheat with a separate `updates` entry per branch.

Most likely this will not work, dependabot cannot bump only security-relevant dependencies in older branches, see  https://github.com/dependabot/dependabot-core/issues/2767#issuecomment-1325799552

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
