### PR TITLE
Revert "Update dependabot.yaml for security updates"

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -9,49 +18,3 @@ updates:
     - "release-note-none"
     - "ok-to-test"
   open-pull-requests-limit: 10
-
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 10
-
-# The list below needs to be maintained manually with every branch we support.
-# It allows dependabot to open security-only updates in supported branches.
-# ("open-pull-requests-limit: 0" blocks non-security updates)
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0
-  target-branch: "release-2.6"
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0
-  target-branch: "release-2.7"
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-
-- package-ecosystem: gomod
-  open-pull-requests-limit: 0
-  target-branch: "release-2.8"
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This reverts commit a68bc84ff866ace5e6d9ef10bf7c527cb4055976.

Testing shows that dependabot did not open any release-2.6 - 2.8 PR. Reverting to the original config.

```release-note
NONE
```
