### PR TITLE
Enable dependabot raising PR by groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,18 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    golang-dependencies:
+      patterns:
+        - "github.com/golang*"
+    k8s-dependencies:
+      patterns:
+        - "k8s.io*"
+        - "sigs.k8s.io*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Discussed in the CSI meeting, we will try to enable another groups feature in a smaller csi sidecar. Refer to PR https://github.com/kubernetes-csi/external-provisioner/pull/990

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @jsafrane
