### PR TITLE
Sync dependabot config from external-provisioner

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,6 +3,8 @@ enable-beta-ecosystems: true
 updates:
 - package-ecosystem: gomod
   directory: "/"
+  allow:
+  - dependency-type: "all"
   schedule:
     interval: weekly
   groups:
@@ -13,6 +15,15 @@ updates:
       patterns:
         - "k8s.io*"
         - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
+    github-dependencies:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "github.com/golang*"
+        - "k8s.io*"
+        - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION
In the external-provisioner repo we experimented with updating *all* dependencies. IMHO it is useful, I'm syncing it to all sidecars.

/kind cleanup
```release-note
NONE
```
