### PR TITLE
Support contextual logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,4 @@ all: build
 
 include release-tools/build.make
 
+test: test-logcheck

--- a/cmd/csi-node-driver-registrar/node_register.go
+++ b/cmd/csi-node-driver-registrar/node_register.go
@@ -39,10 +39,11 @@ func nodeRegister(ctx context.Context, csiDriverName, httpEndpoint string) {
 	// When kubeletRegistrationPath is specified then driver-registrar ONLY acts
 	// as gRPC server which replies to registration requests initiated by kubelet's
 	// plugins watcher infrastructure. Node labeling is done by kubelet's csi code.
+	logger := klog.FromContext(ctx)
 	registrar := newRegistrationServer(csiDriverName, *kubeletRegistrationPath, supportedVersions)
 	socketPath := buildSocketPath(csiDriverName)
 	if err := util.CleanupSocketFile(socketPath); err != nil {
-		klog.ErrorS(err, "")
+		logger.Error(err, "")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
@@ -52,26 +53,32 @@ func nodeRegister(ctx context.Context, csiDriverName, httpEndpoint string) {
 		oldmask, _ = util.Umask(0077)
 	}
 
-	klog.InfoS("Starting Registration Server", "socketPath", socketPath)
+	logger.Info("Starting Registration Server", "socketPath", socketPath)
 	lis, err := net.Listen("unix", socketPath)
 	if err != nil {
-		klog.ErrorS(err, "Failed to listen on socket", "socketPath", socketPath)
+		logger.Error(err, "Failed to listen on socket", "socketPath", socketPath)
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	if runtime.GOOS == "linux" {
 		util.Umask(oldmask)
 	}
-	klog.InfoS("Registration Server started", "socketPath", socketPath)
-	grpcServer := grpc.NewServer()
+
+	logger.Info("Registration Server started", "socketPath", socketPath)
+	opts := []grpc.ServerOption{
+		grpc.UnaryInterceptor(func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+			return handler(klog.NewContext(ctx, logger), req)
+		}),
+	}
+	grpcServer := grpc.NewServer(opts...)
 
 	// Registers kubelet plugin watcher api.
 	registerapi.RegisterRegistrationServer(grpcServer, registrar)
 
 	go httpServer(ctx, socketPath, httpEndpoint, csiDriverName)
-	go removeRegSocket(csiDriverName)
+	go removeRegSocket(logger, csiDriverName)
 	// Starts service
 	if err := grpcServer.Serve(lis); err != nil {
-		klog.ErrorS(err, "Registration Server stopped serving")
+		logger.Error(err, "Registration Server stopped serving")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
@@ -84,40 +91,42 @@ func buildSocketPath(csiDriverName string) string {
 }
 
 func httpServer(ctx context.Context, socketPath string, httpEndpoint string, csiDriverName string) {
+	logger := klog.FromContext(ctx)
 	if httpEndpoint == "" {
-		klog.InfoS("Skipping HTTP server")
+		logger.Info("Skipping HTTP server")
 		return
 	}
-	klog.InfoS("Starting HTTP server", "endpoint", httpEndpoint)
+	logger.Info("Starting HTTP server", "endpoint", httpEndpoint)
 
 	// Prepare http endpoint for healthz + profiling (if enabled)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
+		logger := klog.FromContext(req.Context())
 		socketExists, err := util.DoesSocketExist(socketPath)
 		if err == nil && socketExists {
 			grpcSocketCheckError := checkLiveRegistrationSocket(ctx, socketPath, csiDriverName)
 			if grpcSocketCheckError != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(grpcSocketCheckError.Error()))
-				klog.ErrorS(grpcSocketCheckError, "Health check failed")
+				logger.Error(grpcSocketCheckError, "Health check failed")
 			} else {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`ok`))
-				klog.V(5).InfoS("Health check succeeded")
+				logger.V(5).Info("Health check succeeded")
 			}
 		} else if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
-			klog.ErrorS(err, "Health check failed")
+			logger.Error(err, "Health check failed")
 		} else if !socketExists {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte("registration socket does not exist"))
-			klog.ErrorS(nil, "Health check failed, registration socket does not exist")
+			logger.Error(nil, "Health check failed, registration socket does not exist")
 		}
 	})
 
 	if *enableProfile {
-		klog.InfoS("Starting profiling", "endpoint", httpEndpoint)
+		logger.Info("Starting profiling", "endpoint", httpEndpoint)
 
 		mux.HandleFunc("/debug/pprof/", pprof.Index)
 		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -126,20 +135,21 @@ func httpServer(ctx context.Context, socketPath string, httpEndpoint string, csi
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
 
-	klog.ErrorS(http.ListenAndServe(httpEndpoint, mux), "")
+	logger.Error(http.ListenAndServe(httpEndpoint, mux), "")
 	klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 }
 
 func checkLiveRegistrationSocket(ctx context.Context, socketFile, csiDriverName string) error {
-	klog.V(2).InfoS("Attempting to open a gRPC connection", "socketfile", socketFile)
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Attempting to open a gRPC connection", "socketfile", socketFile)
 	grpcConn, err := connection.ConnectWithoutMetrics(ctx, socketFile)
 	if err != nil {
 		return fmt.Errorf("error connecting to node-registrar socket %s: %v", socketFile, err)
 	}
 
-	defer closeGrpcConnection(socketFile, grpcConn)
+	defer closeGrpcConnection(logger, socketFile, grpcConn)
 
-	klog.V(2).InfoS("Calling node registrar to check if it still responds")
+	logger.V(2).Info("Calling node registrar to check if it still responds")
 	ctx, cancel := context.WithTimeout(context.Background(), *operationTimeout)
 	defer cancel()
 
@@ -158,22 +168,22 @@ func checkLiveRegistrationSocket(ctx context.Context, socketFile, csiDriverName 
 	return fmt.Errorf("invalid driver name %s", info.Name)
 }
 
-func closeGrpcConnection(socketFile string, conn *grpc.ClientConn) {
+func closeGrpcConnection(logger klog.Logger, socketFile string, conn *grpc.ClientConn) {
 	err := conn.Close()
 	if err != nil {
-		klog.ErrorS(err, "Error closing socket", "socketfile", socketFile)
+		logger.Error(err, "Error closing socket", "socketfile", socketFile)
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 }
 
-func removeRegSocket(csiDriverName string) {
+func removeRegSocket(logger klog.Logger, csiDriverName string) {
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGTERM)
 	<-sigc
 	socketPath := buildSocketPath(csiDriverName)
 	err := os.Remove(socketPath)
 	if err != nil && !os.IsNotExist(err) {
-		klog.ErrorS(err, "Failed to remove socket with error", "socket", socketPath)
+		logger.Error(err, "Failed to remove socket with error", "socket", socketPath)
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	os.Exit(0)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -24,7 +24,8 @@ import (
 	"testing"
 
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init"
 )
 
 var socketFileName = "reg.sock"
@@ -88,9 +89,10 @@ func TestSocketPathSimple(t *testing.T) {
 
 	socketPath := filepath.Join(testDir, socketFileName)
 
+	logger, _ := ktesting.NewTestContext(t)
 	_, err = net.Listen("unix", socketPath)
 	if err != nil {
-		klog.ErrorS(err, "Failed to listen on socket", "socketPath", socketPath)
+		logger.Error(err, "Failed to listen on socket", "socketPath", socketPath)
 		os.Exit(1)
 	}
 

--- a/vendor/k8s.io/klog/v2/ktesting/init/init.go
+++ b/vendor/k8s.io/klog/v2/ktesting/init/init.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package init registers the command line flags for k8s.io/klogr/testing in
+// the flag.CommandLine. This is done during initialization, so merely
+// importing it is enough.
+package init
+
+import (
+	"flag"
+
+	"k8s.io/klog/v2/ktesting"
+)
+
+func init() {
+	ktesting.DefaultConfig.AddFlags(flag.CommandLine)
+}

--- a/vendor/k8s.io/klog/v2/ktesting/options.go
+++ b/vendor/k8s.io/klog/v2/ktesting/options.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"flag"
+	"strconv"
+
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+// Config influences logging in a test logger. To make this configurable via
+// command line flags, instantiate this once per program and use AddFlags to
+// bind command line flags to the instance before passing it to NewTestContext.
+//
+// Must be constructed with NewConfig.
+type Config struct {
+	vstate *verbosity.VState
+	co     configOptions
+}
+
+// Verbosity returns a value instance that can be used to query (via String) or
+// modify (via Set) the verbosity threshold. This is thread-safe and can be
+// done at runtime.
+func (c *Config) Verbosity() flag.Value {
+	return c.vstate.V()
+}
+
+// VModule returns a value instance that can be used to query (via String) or
+// modify (via Set) the vmodule settings. This is thread-safe and can be done
+// at runtime.
+func (c *Config) VModule() flag.Value {
+	return c.vstate.VModule()
+}
+
+// ConfigOption implements functional parameters for NewConfig.
+type ConfigOption func(co *configOptions)
+
+type configOptions struct {
+	anyToString       serialize.AnyToStringFunc
+	verbosityFlagName string
+	vmoduleFlagName   string
+	verbosityDefault  int
+	bufferLogs        bool
+}
+
+// AnyToString overrides the default formatter for values that are not
+// supported directly by klog. The default is `fmt.Sprintf("%+v")`.
+// The formatter must not panic.
+func AnyToString(anyToString func(value interface{}) string) ConfigOption {
+	return func(co *configOptions) {
+		co.anyToString = anyToString
+	}
+}
+
+// VerbosityFlagName overrides the default -testing.v for the verbosity level.
+func VerbosityFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+		co.verbosityFlagName = name
+	}
+}
+
+// VModulFlagName overrides the default -testing.vmodule for the per-module
+// verbosity levels.
+func VModuleFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+		co.vmoduleFlagName = name
+	}
+}
+
+// Verbosity overrides the default verbosity level of 5. That default is higher
+// than in klog itself because it enables logging entries for "the steps
+// leading up to errors and warnings" and "troubleshooting" (see
+// https://github.com/kubernetes/community/blob/9406b4352fe2d5810cb21cc3cb059ce5886de157/contributors/devel/sig-instrumentation/logging.md#logging-conventions),
+// which is useful when debugging a failed test. `go test` only shows the log
+// output for failed tests. To see all output, use `go test -v`.
+func Verbosity(level int) ConfigOption {
+	return func(co *configOptions) {
+		co.verbosityDefault = level
+	}
+}
+
+// BufferLogs controls whether log entries are captured in memory in addition
+// to being printed. Off by default. Unit tests that want to verify that
+// log entries are emitted as expected can turn this on and then retrieve
+// the captured log through the Underlier LogSink interface.
+func BufferLogs(enabled bool) ConfigOption {
+	return func(co *configOptions) {
+		co.bufferLogs = enabled
+	}
+}
+
+// NewConfig returns a configuration with recommended defaults and optional
+// modifications. Command line flags are not bound to any FlagSet yet.
+func NewConfig(opts ...ConfigOption) *Config {
+	c := &Config{
+		co: configOptions{
+			verbosityFlagName: "testing.v",
+			vmoduleFlagName:   "testing.vmodule",
+			verbosityDefault:  5,
+		},
+	}
+	for _, opt := range opts {
+		opt(&c.co)
+	}
+
+	c.vstate = verbosity.New()
+	// Cannot fail for this input.
+	_ = c.vstate.V().Set(strconv.FormatInt(int64(c.co.verbosityDefault), 10))
+	return c
+}
+
+// AddFlags registers the command line flags that control the configuration.
+func (c *Config) AddFlags(fs *flag.FlagSet) {
+	fs.Var(c.vstate.V(), c.co.verbosityFlagName, "number for the log level verbosity of the testing logger")
+	fs.Var(c.vstate.VModule(), c.co.vmoduleFlagName, "comma-separated list of pattern=N log level settings for files matching the patterns")
+}

--- a/vendor/k8s.io/klog/v2/ktesting/setup.go
+++ b/vendor/k8s.io/klog/v2/ktesting/setup.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+// DefaultConfig is the global default logging configuration for a unit
+// test. It is used by NewTestContext and k8s.io/klogr/testing/init.
+var DefaultConfig = NewConfig()
+
+// NewTestContext returns a logger and context for use in a unit test case or
+// benchmark. The tl parameter can be a testing.T or testing.B pointer that
+// will receive all log output. Importing k8s.io/klogr/testing/init will add
+// command line flags that modify the configuration of that log output.
+func NewTestContext(tl TL) (logr.Logger, context.Context) {
+	logger := NewLogger(tl, DefaultConfig)
+	ctx := logr.NewContext(context.Background(), logger)
+	return logger, ctx
+
+}

--- a/vendor/k8s.io/klog/v2/ktesting/testinglogger.go
+++ b/vendor/k8s.io/klog/v2/ktesting/testinglogger.go
@@ -1,0 +1,384 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testinglogger contains an implementation of the logr interface
+// which is logging through a function like testing.TB.Log function.
+// Therefore it can be used in standard Go tests and Gingko test suites
+// to ensure that output is associated with the currently running test.
+//
+// In addition, the log data is captured in a buffer and can be used by the
+// test to verify that the code under test is logging as expected. To get
+// access to that data, cast the LogSink into the Underlier type and retrieve
+// it:
+//
+//	logger := ktesting.NewLogger(...)
+//	if testingLogger, ok := logger.GetSink().(ktesting.Underlier); ok {
+//	    t := testingLogger.GetUnderlying()
+//	    buffer := testingLogger.GetBuffer()
+//	    text := buffer.String()
+//	    log := buffer.Data()
+//
+// Serialization of the structured log parameters is done in the same way
+// as for klog.InfoS.
+package ktesting
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/internal/buffer"
+	"k8s.io/klog/v2/internal/dbg"
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/severity"
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+// TL is the relevant subset of testing.TB.
+type TL interface {
+	Helper()
+	Log(args ...interface{})
+}
+
+// NopTL implements TL with empty stubs. It can be used when only capturing
+// output in memory is relevant.
+type NopTL struct{}
+
+func (n NopTL) Helper()            {}
+func (n NopTL) Log(...interface{}) {}
+
+var _ TL = NopTL{}
+
+// BufferTL implements TL with an in-memory buffer.
+type BufferTL struct {
+	strings.Builder
+}
+
+func (n *BufferTL) Helper() {}
+func (n *BufferTL) Log(args ...interface{}) {
+	n.Builder.WriteString(fmt.Sprintln(args...))
+}
+
+var _ TL = &BufferTL{}
+
+// NewLogger constructs a new logger for the given test interface.
+//
+// Beware that testing.T does not support logging after the test that
+// it was created for has completed. If a test leaks goroutines
+// and those goroutines log something after test completion,
+// that output will be printed via the global klog logger with
+// `<test name> leaked goroutine` as prefix.
+//
+// Verbosity can be modified at any time through the Config.V and
+// Config.VModule API.
+func NewLogger(t TL, c *Config) logr.Logger {
+	l := tlogger{
+		shared: &tloggerShared{
+			t:      t,
+			config: c,
+		},
+	}
+	if c.co.anyToString != nil {
+		l.shared.formatter.AnyToStringHook = c.co.anyToString
+	}
+
+	type testCleanup interface {
+		Cleanup(func())
+		Name() string
+	}
+
+	// Stopping the logging is optional and only done (and required)
+	// for testing.T/B/F.
+	if tb, ok := t.(testCleanup); ok {
+		tb.Cleanup(l.shared.stop)
+		l.shared.testName = tb.Name()
+	}
+	return logr.New(l)
+}
+
+// Buffer stores log entries as formatted text and structured data.
+// It is safe to use this concurrently.
+type Buffer interface {
+	// String returns the log entries in a format that is similar to the
+	// klog text output.
+	String() string
+
+	// Data returns the log entries as structs.
+	Data() Log
+}
+
+// Log contains log entries in the order in which they were generated.
+type Log []LogEntry
+
+// DeepCopy returns a copy of the log. The error instance and key/value
+// pairs remain shared.
+func (l Log) DeepCopy() Log {
+	log := make(Log, 0, len(l))
+	log = append(log, l...)
+	return log
+}
+
+// LogEntry represents all information captured for a log entry.
+type LogEntry struct {
+	// Timestamp stores the time when the log entry was created.
+	Timestamp time.Time
+
+	// Type is either LogInfo or LogError.
+	Type LogType
+
+	// Prefix contains the WithName strings concatenated with a slash.
+	Prefix string
+
+	// Message is the fixed log message string.
+	Message string
+
+	// Verbosity is always 0 for LogError.
+	Verbosity int
+
+	// Err is always nil for LogInfo. It may or may not be
+	// nil for LogError.
+	Err error
+
+	// WithKVList are the concatenated key/value pairs from WithValues
+	// calls. It's guaranteed to have an even number of entries because
+	// the logger ensures that when WithValues is called.
+	WithKVList []interface{}
+
+	// ParameterKVList are the key/value pairs passed into the call,
+	// without any validation.
+	ParameterKVList []interface{}
+}
+
+// LogType determines whether a log entry was created with an Error or Info
+// call.
+type LogType string
+
+const (
+	// LogError is the special value used for Error log entries.
+	LogError = LogType("ERROR")
+
+	// LogInfo is the special value used for Info log entries.
+	LogInfo = LogType("INFO")
+)
+
+// Underlier is implemented by the LogSink of this logger. It provides access
+// to additional APIs that are normally hidden behind the Logger API.
+type Underlier interface {
+	// GetUnderlying returns the testing instance that logging goes to.
+	// It returns nil when the test has completed already.
+	GetUnderlying() TL
+
+	// GetBuffer grants access to the in-memory copy of the log entries.
+	GetBuffer() Buffer
+}
+
+type logBuffer struct {
+	mutex sync.Mutex
+	text  strings.Builder
+	log   Log
+}
+
+func (b *logBuffer) String() string {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.text.String()
+}
+
+func (b *logBuffer) Data() Log {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.log.DeepCopy()
+}
+
+// tloggerShared holds values that are the same for all LogSink instances. It
+// gets referenced by pointer in the tlogger struct.
+type tloggerShared struct {
+	// mutex protects access to t.
+	mutex sync.Mutex
+
+	// t gets cleared when the test is completed.
+	t TL
+
+	// We warn once when a leaked goroutine is detected because
+	// it logs after test completion.
+	goroutineWarningDone bool
+
+	formatter serialize.Formatter
+	testName  string
+	config    *Config
+	buffer    logBuffer
+	callDepth int
+}
+
+func (ls *tloggerShared) stop() {
+	ls.mutex.Lock()
+	defer ls.mutex.Unlock()
+	ls.t = nil
+}
+
+// tlogger is the actual LogSink implementation.
+type tlogger struct {
+	shared *tloggerShared
+	prefix string
+	values []interface{}
+}
+
+func (l tlogger) fallbackLogger() logr.Logger {
+	logger := klog.Background().WithValues(l.values...).WithName(l.shared.testName + " leaked goroutine")
+	if l.prefix != "" {
+		logger = logger.WithName(l.prefix)
+	}
+	// Skip direct caller (= Error or Info) plus the logr wrapper.
+	logger = logger.WithCallDepth(l.shared.callDepth + 1)
+
+	if !l.shared.goroutineWarningDone {
+		logger.WithCallDepth(1).Error(nil, "WARNING: test kept at least one goroutine running after test completion", "callstack", string(dbg.Stacks(false)))
+		l.shared.goroutineWarningDone = true
+	}
+	return logger
+}
+
+func (l tlogger) Init(info logr.RuntimeInfo) {
+	l.shared.callDepth = info.CallDepth
+}
+
+func (l tlogger) GetCallStackHelper() func() {
+	l.shared.mutex.Lock()
+	defer l.shared.mutex.Unlock()
+	if l.shared.t == nil {
+		return func() {}
+	}
+
+	return l.shared.t.Helper
+}
+
+func (l tlogger) Info(level int, msg string, kvList ...interface{}) {
+	l.shared.mutex.Lock()
+	defer l.shared.mutex.Unlock()
+	if l.shared.t == nil {
+		l.fallbackLogger().V(level).Info(msg, kvList...)
+		return
+	}
+
+	l.shared.t.Helper()
+	buf := buffer.GetBuffer()
+	l.shared.formatter.MergeAndFormatKVs(&buf.Buffer, l.values, kvList)
+	l.log(LogInfo, msg, level, buf, nil, kvList)
+}
+
+func (l tlogger) Enabled(level int) bool {
+	return l.shared.config.vstate.Enabled(verbosity.Level(level), 1)
+}
+
+func (l tlogger) Error(err error, msg string, kvList ...interface{}) {
+	l.shared.mutex.Lock()
+	defer l.shared.mutex.Unlock()
+	if l.shared.t == nil {
+		l.fallbackLogger().Error(err, msg, kvList...)
+		return
+	}
+
+	l.shared.t.Helper()
+	buf := buffer.GetBuffer()
+	if err != nil {
+		l.shared.formatter.KVFormat(&buf.Buffer, "err", err)
+	}
+	l.shared.formatter.MergeAndFormatKVs(&buf.Buffer, l.values, kvList)
+	l.log(LogError, msg, 0, buf, err, kvList)
+}
+
+func (l tlogger) log(what LogType, msg string, level int, buf *buffer.Buffer, err error, kvList []interface{}) {
+	l.shared.t.Helper()
+	s := severity.InfoLog
+	if what == LogError {
+		s = severity.ErrorLog
+	}
+	args := []interface{}{buf.SprintHeader(s, time.Now())}
+	if l.prefix != "" {
+		args = append(args, l.prefix+":")
+	}
+	args = append(args, msg)
+	if buf.Len() > 0 {
+		// Skip leading space inserted by serialize.KVListFormat.
+		args = append(args, string(buf.Bytes()[1:]))
+	}
+	l.shared.t.Log(args...)
+
+	if !l.shared.config.co.bufferLogs {
+		return
+	}
+
+	l.shared.buffer.mutex.Lock()
+	defer l.shared.buffer.mutex.Unlock()
+
+	// Store as text.
+	l.shared.buffer.text.WriteString(string(what))
+	for i := 1; i < len(args); i++ {
+		l.shared.buffer.text.WriteByte(' ')
+		l.shared.buffer.text.WriteString(args[i].(string))
+	}
+	lastArg := args[len(args)-1].(string)
+	if lastArg[len(lastArg)-1] != '\n' {
+		l.shared.buffer.text.WriteByte('\n')
+	}
+
+	// Store as raw data.
+	l.shared.buffer.log = append(l.shared.buffer.log,
+		LogEntry{
+			Timestamp:       time.Now(),
+			Type:            what,
+			Prefix:          l.prefix,
+			Message:         msg,
+			Verbosity:       level,
+			Err:             err,
+			WithKVList:      l.values,
+			ParameterKVList: kvList,
+		},
+	)
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l tlogger) WithName(name string) logr.LogSink {
+	if len(l.prefix) > 0 {
+		l.prefix = l.prefix + "/"
+	}
+	l.prefix += name
+	return l
+}
+
+func (l tlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.values = serialize.WithValues(l.values, kvList)
+	return l
+}
+
+func (l tlogger) GetUnderlying() TL {
+	return l.shared.t
+}
+
+func (l tlogger) GetBuffer() Buffer {
+	return &l.shared.buffer
+}
+
+var _ logr.LogSink = &tlogger{}
+var _ logr.CallStackHelperLogSink = &tlogger{}
+var _ Underlier = &tlogger{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -341,6 +341,8 @@ k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
 k8s.io/klog/v2/internal/sloghandler
 k8s.io/klog/v2/internal/verbosity
+k8s.io/klog/v2/ktesting
+k8s.io/klog/v2/ktesting/init
 k8s.io/klog/v2/textlogger
 # k8s.io/kube-openapi v0.0.0-20240430033511-f0e62f92d13f
 ## explicit; go 1.20


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
-->

/kind feature

**What this PR does / why we need it**:

I've updated the klog functions used within node-driver-registrar to contextual logging functions, following the guidelines below:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

- Added contextual logging checks using logcheck. (You can run logcheck with `make test` or `make logcheck`)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support for contextual logging.
```
