### PR TITLE
Fix registrar timeout

### DIFF
--- a/cmd/csi-node-driver-registrar/main.go
+++ b/cmd/csi-node-driver-registrar/main.go
@@ -178,10 +178,10 @@ func main() {
 	}
 
 	logger.V(1).Info("Calling CSI driver to discover driver name")
-	ctx, cancel := context.WithTimeout(ctx, *operationTimeout)
+	getNameCtx, cancel := context.WithTimeout(ctx, *operationTimeout)
 	defer cancel()
 
-	csiDriverName, err := csirpc.GetDriverName(ctx, csiConn)
+	csiDriverName, err := csirpc.GetDriverName(getNameCtx, csiConn)
 	if err != nil {
 		logger.Error(err, "Error retreiving CSI driver name")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Use a background context for the registrar main function and not the context for `GetDriverName` that has 1 second timeout by default.

The registrar should run forever and not for 1 second.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #425

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed node-driver-registrar exiting after 1 second.
```
