### PR TITLE
Automated cherry pick of #426: Fix registrar timeout

### DIFF
--- a/cmd/csi-node-driver-registrar/main.go
+++ b/cmd/csi-node-driver-registrar/main.go
@@ -178,10 +178,10 @@ func main() {
 	}
 
 	logger.V(1).Info("Calling CSI driver to discover driver name")
-	ctx, cancel := context.WithTimeout(ctx, *operationTimeout)
+	getNameCtx, cancel := context.WithTimeout(ctx, *operationTimeout)
 	defer cancel()
 
-	csiDriverName, err := csirpc.GetDriverName(ctx, csiConn)
+	csiDriverName, err := csirpc.GetDriverName(getNameCtx, csiConn)
 	if err != nil {
 		logger.Error(err, "Error retreiving CSI driver name")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)


### PR DESCRIPTION
Cherry pick of #426 on release-2.11.

#426: Fix registrar timeout

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```