### PR TITLE
Bump go version to fix CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/node-driver-registrar
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/kubernetes-csi/csi-lib-utils v0.19.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Image version v2.12.0 contains the following CVEs according to trivy:

* [CVE-2024-34156](https://avd.aquasec.com/nvd/cve-2024-34156) (HIGH)
* [CVE-2024-34155](https://avd.aquasec.com/nvd/cve-2024-34155) (MEDIUM)
* [CVE-2024-34158](https://avd.aquasec.com/nvd/cve-2024-34158) (MEDIUM)

Fixed in go version 1.22.7 or 1.23.1.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```