### PR TITLE
update log level verbosity to not clutter logs

### DIFF
--- a/cmd/csi-node-driver-registrar/main.go
+++ b/cmd/csi-node-driver-registrar/main.go
@@ -96,7 +96,7 @@ func newRegistrationServer(driverName string, endpoint string, versions []string
 // GetInfo is the RPC invoked by plugin watcher
 func (e registrationServer) GetInfo(ctx context.Context, req *registerapi.InfoRequest) (*registerapi.PluginInfo, error) {
 	logger := klog.FromContext(ctx)
-	logger.Info("Received GetInfo call", "request", req)
+	logger.V(4).Info("Received GetInfo call", "request", req)
 
 	return &registerapi.PluginInfo{
 		Type:              registerapi.CSIPlugin,

--- a/cmd/csi-node-driver-registrar/node_register.go
+++ b/cmd/csi-node-driver-registrar/node_register.go
@@ -141,7 +141,7 @@ func httpServer(ctx context.Context, socketPath string, httpEndpoint string, csi
 
 func checkLiveRegistrationSocket(ctx context.Context, socketFile, csiDriverName string) error {
 	logger := klog.FromContext(ctx)
-	logger.V(2).Info("Attempting to open a gRPC connection", "socketfile", socketFile)
+	logger.V(4).Info("Attempting to open a gRPC connection", "socketfile", socketFile)
 	grpcConn, err := connection.ConnectWithoutMetrics(ctx, socketFile)
 	if err != nil {
 		return fmt.Errorf("error connecting to node-registrar socket %s: %v", socketFile, err)
@@ -149,7 +149,7 @@ func checkLiveRegistrationSocket(ctx context.Context, socketFile, csiDriverName 
 
 	defer closeGrpcConnection(logger, socketFile, grpcConn)
 
-	logger.V(2).Info("Calling node registrar to check if it still responds")
+	logger.V(4).Info("Calling node registrar to check if it still responds")
 	ctx, cancel := context.WithTimeout(context.Background(), *operationTimeout)
 	defer cancel()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the logs are being cluttered by unnecessary logs, ie this being repeated in logs every minute:
```
I0925 10:46:16.688244 1 main.go:99] "Received GetInfo call" request=""
10
I0925 10:46:16.747727 1 main.go:111] "Received NotifyRegistrationStatus call" status="plugin_registered:true"
11
I0925 10:46:34.500493 1 node_register.go:144] "Attempting to open a gRPC connection" socketfile="test.sock"
12
I0925 10:46:34.501191 1 node_register.go:152] "Calling node registrar to check if it still responds"
```
This pr fixes it by bumping few log levels.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed overflowing of logs, gRPC connection logs are now on V(4) log level.
```
