### PR TITLE
Run Trivy scan on schedule instead of pull requests

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
 jobs:
   build:
     name: Build


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The Trivy vulnerability scanner GitHub Action currently runs on every pull request, which blocks and delays dev work. This was discussed with sig-storage lead @xing-yang and we agreed to move it to a daily scheduled run instead. This way we still catch vulnerabilities but PRs to master aren't held up on dep bumps.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # NA

**Special notes for your reviewer**:

This is part of a coordinated change across all kubernetes-csi repos that have the Trivy workflow. Same change is being applied across the board.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

cc: @jsafrane 
