### PR TITLE
Fixing CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/node-driver-registrar
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/kubernetes-csi/csi-lib-utils v0.23.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/node-driver-registrar
 
-go 1.25.0
+go 1.25.9
 
 require (
 	github.com/kubernetes-csi/csi-lib-utils v0.23.2


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR upgrades the Go version in go.mod to `1.25.10`, which resolves multiple known vulnerabilities in the dependency tree and standard library.

**Which issue(s) this PR fixes**:
This PR fixes the following CVE's:
- CVE-2026-32280
- CVE-2026-32281
- CVE-2026-32283
- CVE-2026-33810
- CVE-2026-25679
- CVE-2026-27137
- CVE-2026-39823
- CVE-2026-39826
- CVE-2026-33811
- CVE-2026-39836
- CVE-2026-33811
- CVE-2026-39820
- CVE-2026-39823
- CVE-2026-39825
- CVE-2026-39826
- CVE-2026-39836
- CVE-2026-42499

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
