### PR TITLE
Update Go version from 1.26.5 to 1.26.6 to fix CVEs (release-2.17)

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.26.5" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.26.6" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
Sync `release-tools/` from `kubernetes-csi/csi-release-tools@master` to release-2.17, which bumps `CSI_PROW_GO_VERSION_BUILD` from `1.26.5` to `1.26.6` to pick up the recent stdlib CVE fixes:

- CVE-2026-39821 (net/http, x/net/idna Punycode)
- CVE-2026-33818 (encoding/asn1 recursion depth)
- CVE-2026-56853 (net/http h2c ReadHeaderTimeout)
- CVE-2026-56858 (html/template regexp context)
- CVE-2026-56859 (encoding/xml recursion depth)
- CVE-2026-56860 (net/url resolvePath quadratic)
- CVE-2026-56862 (crypto/tls post-handshake message cap)

Pulled with:
```
git subtree pull --squash --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master
```

/kind bug
/release-note-none